### PR TITLE
FrontControllerServletV5에 ControllerV4 기능 추가

### DIFF
--- a/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
+++ b/src/main/java/hello/servlet/web/frontcontroller/v5/FrontControllerServletV5.java
@@ -5,7 +5,11 @@ import hello.servlet.web.frontcontroller.MyView;
 import hello.servlet.web.frontcontroller.v3.controller.MemberFormControllerV3;
 import hello.servlet.web.frontcontroller.v3.controller.MemberListControllerV3;
 import hello.servlet.web.frontcontroller.v3.controller.MemberSaveControllerV3;
-import hello.servlet.web.servletmvc.ControllerV3HandlerAdapter;
+import hello.servlet.web.frontcontroller.v4.controller.MemberFormControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberListControllerV4;
+import hello.servlet.web.frontcontroller.v4.controller.MemberSaveControllerV4;
+import hello.servlet.web.frontcontroller.v5.adapter.ControllerV3HandlerAdapter;
+import hello.servlet.web.frontcontroller.v5.adapter.ControllerV4HandlerAdapter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -34,10 +38,16 @@ public class FrontControllerServletV5 extends HttpServlet {
         handlerMappingMap.put("/front-controller/v5/v3/members/new-form", new MemberFormControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members/save", new MemberSaveControllerV3());
         handlerMappingMap.put("/front-controller/v5/v3/members", new MemberListControllerV3());
+
+        // V4 추가
+        handlerMappingMap.put("/front-controller/v5/v4/members/new-form", new MemberFormControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members/save", new MemberSaveControllerV4());
+        handlerMappingMap.put("/front-controller/v5/v4/members", new MemberListControllerV4());
     }
 
     private void initHandlerAdapters() {
         handlerAdapters.add(new ControllerV3HandlerAdapter());
+        handlerAdapters.add(new ControllerV4HandlerAdapter());
     }
 
     @Override

--- a/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV3HandlerAdapter.java
+++ b/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV3HandlerAdapter.java
@@ -1,4 +1,4 @@
-package hello.servlet.web.servletmvc;
+package hello.servlet.web.frontcontroller.v5.adapter;
 
 import hello.servlet.web.frontcontroller.ModelView;
 import hello.servlet.web.frontcontroller.v3.ControllerV3;

--- a/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV4HandlerAdapter.java
+++ b/src/main/java/hello/servlet/web/frontcontroller/v5/adapter/ControllerV4HandlerAdapter.java
@@ -1,0 +1,42 @@
+package hello.servlet.web.frontcontroller.v5.adapter;
+
+import hello.servlet.web.frontcontroller.ModelView;
+import hello.servlet.web.frontcontroller.v4.ControllerV4;
+import hello.servlet.web.frontcontroller.v5.MyHandlerAdapter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerV4HandlerAdapter implements MyHandlerAdapter {
+
+    @Override
+    public boolean supports(Object handler) {
+        return (handler instanceof ControllerV4);
+    }
+
+    @Override
+    public ModelView handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+        ControllerV4 controller = (ControllerV4) handler;
+
+        Map<String, String> paramMap = createParamMap(request);
+        HashMap<String, Object> model = new HashMap<>();
+
+        String viewName = controller.process(paramMap, model);
+
+        ModelView mv = new ModelView(viewName);
+        mv.setModel(model);
+
+        return mv;
+    }
+
+    private static Map<String, String> createParamMap(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(paramName -> paramMap.put(paramName, request.getParameter(paramName)));
+        return paramMap;
+    }
+}


### PR DESCRIPTION
### FrontControllerServletV5에 ControllerV4 기능 추가

#### 📌 변경 사항
- `handlerMappingMap`에 `ControllerV4`를 사용하는 컨트롤러 추가
- `ControllerV4HandlerAdapter`를 추가하여 V4 컨트롤러 처리 가능하도록 개선
- 기존 `ControllerV3`와 함께 `ControllerV4`도 `FrontControllerServletV5`에서 사용할 수 있도록 변경
- 어댑터 패턴을 적용하여 새로운 컨트롤러 유형 추가가 용이하도록 설계

#### 🔍 주요 구현 내용
- `ControllerV4HandlerAdapter`를 생성하여 `ControllerV4`를 `ModelView`로 변환하는 역할 수행
- `supports` 메서드를 통해 `ControllerV4` 여부를 확인하고 적절한 어댑터를 사용
- 기존 `ControllerV3HandlerAdapter`와 함께 여러 타입의 컨트롤러를 처리할 수 있도록 확장

#### ✅ 테스트 및 확인
- `/front-controller/v5/v4/members/new-form` 페이지에서 회원 등록 폼 정상 렌더링 확인
- `/front-controller/v5/v4/members` 페이지에서 회원 목록 조회 정상 동작 확인
- 기존 V3 컨트롤러와 함께 V4 컨트롤러도 정상적으로 작동하는지 테스트 완료

#### 🚀 기대 효과
- 컨트롤러 구조가 유연해져 다양한 방식의 컨트롤러를 지원할 수 있음
- 어댑터 패턴을 활용하여 기존 구조를 유지하면서 새로운 컨트롤러 방식 추가 가능
- 향후 애노테이션 기반 컨트롤러를 추가하여 더 편리한 프레임워크로 발전 가능

